### PR TITLE
Fix import for python 3

### DIFF
--- a/cm15/__init__.py
+++ b/cm15/__init__.py
@@ -9,7 +9,7 @@ import sys
 import threading
 import usb
 import time
-from x10 import X10
+from .x10 import X10
 from pprint import pprint
 
 class CM15():


### PR DESCRIPTION
Importing the X10 class fails on python 3.5.1. This fixes the import. I tested it with python 2.7 and it the module still works there, so I don't think there are any conflicts.
